### PR TITLE
Update tokenization example in README with correct submodule level import

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ The `SentenceTokenizer` class is designed to split a given text into individual 
 Below is an example of how to use the `SentenceTokenizer`:
 
 ```python
-from shekar.tokenizers import SentenceTokenizer
+from shekar.tokenization import SentenceTokenizer
 
 text = "هدف ما کمک به یکدیگر است! ما می‌توانیم با هم کار کنیم."
 tokenizer = SentenceTokenizer()


### PR DESCRIPTION
When reviewing for JOSS I was trying all of the examples in the README and ran into an issue with just this one. I couldn't import the submodule "tokenizers" but I could import "tokenization."